### PR TITLE
Fix Record.php make string $key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ public_html/hot
 storage/*.key
 .env
 .phpunit.result.cache
+.phpunit.cache
+.phpunit.xml.bak

--- a/src/Record.php
+++ b/src/Record.php
@@ -336,7 +336,7 @@ final class Record
     {
         return array_filter($cookies, function ($key) {
             foreach ($this->hiddenCookies as $hiddenCookie) {
-                if (str_contains($key, $hiddenCookie)) {
+                if (str_contains((string)$key, $hiddenCookie)) {
                     return false;
                 }
             }


### PR DESCRIPTION
Fixes error: str_contains(): Argument #1 ($haystack) must be of type string, int given at /var/www/html/vendor/ucraft-com/http-traffic-logger/src/Record.php:339)